### PR TITLE
Add Safe Wallet to list of wallets

### DIFF
--- a/docs/pages/ecosystem/wallets.mdx
+++ b/docs/pages/ecosystem/wallets.mdx
@@ -1,4 +1,4 @@
 # Wallets that support EIP-5792
 
 * Coinbase Smart Wallet
-* [Safe{Wallet}](https://github.com/safe-global/safe-wallet-web) – _can connect to dapps via WalletConnect and supports transaction batching natively_
+* [Safe\{Wallet\}](https://github.com/safe-global/safe-wallet-web) – _can connect to dapps via WalletConnect and supports transaction batching natively_

--- a/docs/pages/ecosystem/wallets.mdx
+++ b/docs/pages/ecosystem/wallets.mdx
@@ -1,3 +1,4 @@
 # Wallets that support EIP-5792
 
 * Coinbase Smart Wallet
+* [Safe{Wallet}](https://github.com/safe-global/safe-wallet-web) – _can connect to dapps via WalletConnect and supports transaction batching natively_


### PR DESCRIPTION
Safe{Wallet} supports 5792 so I'd like to add it to https://www.eip5792.xyz/ecosystem/wallets

Thanks!