### PR TITLE
chore: add Ekubo to app ecosystem

### DIFF
--- a/docs/pages/ecosystem/apps.mdx
+++ b/docs/pages/ecosystem/apps.mdx
@@ -10,3 +10,4 @@ This list is not exhaustive. If you know of an app that leverages EIP-5792, plea
 * [Lido](https://lido.fi/)
 * [LI.FI](https://li.fi)
 * [Jumper.Exchange](https://jumper.exchange/)
+* [Ekubo](https://evm.ekubo.org)


### PR DESCRIPTION
Hey @lukasrosario, Ekubo supports 5792 on mainnet to send approve + swap / approves + add liquidity now :)